### PR TITLE
recipes-containers: docker: force enable dockerd at every boot

### DIFF
--- a/recipes-containers/docker/docker-ce_%.bbappend
+++ b/recipes-containers/docker/docker-ce_%.bbappend
@@ -1,0 +1,12 @@
+# The only enabled service in docker-ce_git.bb is docker.socket,
+# but on our embedded device we want dockerd to start all the time.
+# With docker.socket enabled, dockerd starts only when it is 
+# contacted through its socket.
+
+DOCKERD_SERVICE_PACKAGE := "dockerd-service"
+
+PACKAGES =+ "${DOCKERD_SERVICE_PACKAGE}"
+SYSTEMD_PACKAGES += "${DOCKERD_SERVICE_PACKAGE}"
+SYSTEMD_SERVICE_${DOCKERD_SERVICE_PACKAGE} = "docker.service"
+
+RDEPENDS_${PN} += "${DOCKERD_SERVICE_PACKAGE}"


### PR DESCRIPTION
Only docker.socket was enabled, which was causing a start of dockerd only when 'docker' command was invoked. We now start dockerd all the time, so that required containers can start automatically.